### PR TITLE
refactor(componentDidMount): pass this to the callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [HEAD]
 > Unreleased
 
+* [Breaking] refactor(componentDidMount): pass this to the callback
+
+
 ## [v1.0.4]
 > Mar 26, 2016
 

--- a/src/componentDidMount.js
+++ b/src/componentDidMount.js
@@ -4,7 +4,7 @@ import createHelper from 'recompose/createHelper';
 
 const componentDidMount = (callback, BaseComponent) =>
   class extends React.Component {
-    componentDidMount = () => callback(this.props)
+    componentDidMount = () => callback(this)
     render = () => createElement(BaseComponent, this.props)
   };
 


### PR DESCRIPTION
Invoke the passed callback with `this` instead of `this.props` as the argument.

BREAKING CHANGE:
To migrate, you can change callbacks from `(props) => {}` to `({ props }) => {}`.
Closes #15
